### PR TITLE
Include necessary launch options for Chrome

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,4 @@ FROM jsreport/jsreport:2.11.0
 COPY --chown=jsreport:jsreport server.js /app/server.js
 COPY --chown=jsreport:jsreport data /app/data
 
-ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=
-
-RUN npm i --save
-
 CMD ["bash", "/app/run.sh"]

--- a/stack.yml
+++ b/stack.yml
@@ -38,5 +38,5 @@ networks:
 
 secrets:
  jsreport.config.json:
-  name: make-a-pdf.config.json_2021-12-10
+  name: make-a-pdf.config.json_2021-12-13
   external: true


### PR DESCRIPTION
The launch options are defined in the config file which is a secret
because it also contains passwords and other secrets.